### PR TITLE
Change Image to portainer/portainer-ce

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -27,6 +27,11 @@ ADMIN_PASSWORD=your_admin_password
 DOMAINS=portainer.domain.com,portainer2.domain.com
 
 #
+# Port for portainer
+#
+PORT=9000
+
+#
 # Main domain for SSL certificate
 #
 MAIN_DOMAIN=portainer.domain.com

--- a/docker-compose-with-password.yml
+++ b/docker-compose-with-password.yml
@@ -4,13 +4,14 @@ services:
   portainer:
     container_name: ${CONTAINER_NAME}
     restart: unless-stopped
-    image: portainer/portainer
+    image: portainer/portainer-ce
     volumes:
       - ${PORTAINER_DATA_PATH}:/data
       - ${PORTAINER_SSL_PATH}:/certs
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       VIRTUAL_HOST: ${DOMAINS}
+      VIRTUAL_PORT: ${PORT}
       LETSENCRYPT_HOST: ${DOMAINS}
       LETSENCRYPT_EMAIL: ${LETSENCRYPT_EMAIL}
       SSL:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,14 @@ services:
   portainer:
     container_name: ${CONTAINER_NAME}
     restart: unless-stopped
-    image: portainer/portainer
+    image: portainer/portainer-ce
     volumes:
       - ${PORTAINER_DATA_PATH}:/data
       - ${PORTAINER_SSL_PATH}:/certs
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       VIRTUAL_HOST: ${DOMAINS}
+      VIRTUAL_PORT: ${PORT}
       LETSENCRYPT_HOST: ${DOMAINS}
       LETSENCRYPT_EMAIL: ${LETSENCRYPT_EMAIL}
       SSL:


### PR DESCRIPTION
- [portainer/portainer](https://hub.docker.com/r/portainer/portainer) is no longer available
- [portainer/portainer-ce](https://hub.docker.com/r/portainer/portainer-ce) is the new one
- adding ``VIRTUAL_PORT` is needed to make nginx and letsencrypt work again
