### PR TITLE
fix: network.external.name is deprecated

### DIFF
--- a/docker-compose-with-password.yml
+++ b/docker-compose-with-password.yml
@@ -20,6 +20,5 @@ services:
     command: --admin-password ${ENCRYPTED_PASSWORD}
 
 networks:
-    default:
-      external: true
-      name: ${NETWORK}
+  portainer_network:
+    name: ${NETWORK}

--- a/docker-compose-with-password.yml
+++ b/docker-compose-with-password.yml
@@ -21,5 +21,5 @@ services:
 
 networks:
     default:
-       external:
-         name: ${NETWORK}
+      external: true
+      name: ${NETWORK}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,5 +20,5 @@ services:
 
 networks:
     default:
-       external:
-         name: ${NETWORK}
+       external: true
+       name: ${NETWORK}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,5 @@ services:
       SSLKEY: ${PORTAINER_SSL_KEY}
 
 networks:
-    default:
-       external: true
-       name: ${NETWORK}
+  portainer_network:
+    name: ${NETWORK}


### PR DESCRIPTION
Close #12